### PR TITLE
fix: lightningcss-loader should not receive js comments

### DIFF
--- a/rspack/lightingcss-loader/rspack.config.js
+++ b/rspack/lightingcss-loader/rspack.config.js
@@ -5,7 +5,7 @@ const config = {
   module: {
     rules: [
       {
-        test: /answer\.css$/,
+        test: /\.css$/,
         use: [
           {
             loader: 'builtin:lightningcss-loader',
@@ -17,28 +17,12 @@ const config = {
         ],
         type: 'css',
       },
-      {
-        test: /.css$/,
-        use: [
-          rspack.CssExtractRspackPlugin.loader,
-          'css-loader',
-          {
-            loader: 'builtin:lightningcss-loader',
-            /** @type {import('@rspack/core').LightningcssLoaderOptions} */
-            options: {
-              targets: 'ie 10',
-            },
-          },
-        ],
-        type: 'javascript/auto',
-      },
     ],
   },
   plugins: [
     new rspack.HtmlRspackPlugin({
       template: './index.html',
     }),
-    new rspack.CssExtractRspackPlugin(),
   ],
   experiments: {
     css: true,


### PR DESCRIPTION
Should not use `experiments.css` and `css-extract` the same time. It would create the same css chunk with the same name and this is an error for emitting files.