### PR TITLE
docs: update README with gitpick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,35 @@ This repository contains comprehensive examples that demonstrate the Rstack ecos
 
 ## List of Examples
 
-|   [Rspack](https://github.com/web-infra-dev/rspack)   |  <a href="https://github.com/web-infra-dev/rspack" target="blank"><img src="https://assets.rspack.dev/rspack/rspack-banner.png" width="400" /></a>  |  [Examples](./rspack)   |  [Document](https://rspack.dev/)  |
-| :---------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------: | :-------------------------------: |
-|  [Rsbuild](https://github.com/web-infra-dev/rsbuild)  | <a href="https://github.com/web-infra-dev/rsbuild" target="blank"><img src="https://assets.rspack.dev/rsbuild/rsbuild-banner.png" width="400" /></a>  |  [Examples](./rsbuild)  | [Document](https://rsbuild.dev/)  |
-|  [Rspress](https://github.com/web-infra-dev/rspress)  | <a href="https://github.com/web-infra-dev/rspress" target="blank"><img src="https://assets.rspack.dev/rspress/rspress-banner.png" width="400" /></a>  | [Examples](./rspress/)  | [Document](https://rspress.dev/)  |
-| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | <a href="https://github.com/web-infra-dev/rsdoctor" target="blank"><img src="https://assets.rspack.dev/rsdoctor/rsdoctor-banner.png" width="400" /></a> | [Examples](./rsdoctor/) | [Document](https://rsdoctor.dev/) |
-| [Rslib](https://github.com/web-infra-dev/rslib) | <a href="https://github.com/web-infra-dev/rslib" target="blank"><img src="https://assets.rspack.dev/rslib/rslib-banner.png" width="400" /></a> | [Examples](https://github.com/web-infra-dev/rslib/tree/main/examples) | [Document](https://lib.rsbuild.dev/) |
+|   [Rspack](https://github.com/web-infra-dev/rspack)   |    <a href="https://github.com/web-infra-dev/rspack" target="blank"><img src="https://assets.rspack.dev/rspack/rspack-banner.png" width="400" /></a>    |                         [Examples](./rspack)                          |   [Document](https://rspack.dev/)    |
+| :---------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------: | :----------------------------------: |
+|  [Rsbuild](https://github.com/web-infra-dev/rsbuild)  |  <a href="https://github.com/web-infra-dev/rsbuild" target="blank"><img src="https://assets.rspack.dev/rsbuild/rsbuild-banner.png" width="400" /></a>   |                         [Examples](./rsbuild)                         |   [Document](https://rsbuild.dev/)   |
+|  [Rspress](https://github.com/web-infra-dev/rspress)  |  <a href="https://github.com/web-infra-dev/rspress" target="blank"><img src="https://assets.rspack.dev/rspress/rspress-banner.png" width="400" /></a>   |                        [Examples](./rspress/)                         |   [Document](https://rspress.dev/)   |
+| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | <a href="https://github.com/web-infra-dev/rsdoctor" target="blank"><img src="https://assets.rspack.dev/rsdoctor/rsdoctor-banner.png" width="400" /></a> |                        [Examples](./rsdoctor/)                        |  [Document](https://rsdoctor.dev/)   |
+|    [Rslib](https://github.com/web-infra-dev/rslib)    |     <a href="https://github.com/web-infra-dev/rslib" target="blank"><img src="https://assets.rspack.dev/rslib/rslib-banner.png" width="400" /></a>      | [Examples](https://github.com/web-infra-dev/rslib/tree/main/examples) | [Document](https://lib.rsbuild.dev/) |
 
 ## How to Use
+
+### Clone single example
+
+To clone a single example, you can use the [gitpick](https://github.com/nrjdalal/gitpick) to clone a sub-directory from the current repository.
+
+For example, to clone the `/rspack/basic` example, run the following command:
+
+```bash
+# Clone the basic example
+npx gitpick https://github.com/rspack-contrib/rstack-examples/tree/main/rspack/basic
+
+# Enter the basic example directory
+cd basic
+
+# Install the dependencies
+pnpm i
+```
+
+### Clone all examples
+
+To try all examples, you can clone the current repository to your local.
 
 1. First, clone the current repository to your local:
 


### PR DESCRIPTION
This pull request updates the `README.md` file to improve documentation for cloning examples and fixes a formatting issue in the examples table. Below are the key changes:

### Documentation Enhancements:
* Added a new section, "Clone single example," to explain how to use the `gitpick` tool for cloning specific sub-directories from the repository. This includes a step-by-step example for cloning the `/rspack/basic` example.
* Added a "Clone all examples" section to clarify the steps for cloning the entire repository.

### Formatting Fix:
* Fixed alignment issues in the examples table by updating column formatting for better readability.