### PR TITLE
feat: use special cacheGroups to handle vanilla extract modules

### DIFF
--- a/rsbuild/vanilla-extract/rsbuild.config.ts
+++ b/rsbuild/vanilla-extract/rsbuild.config.ts
@@ -10,6 +10,21 @@ export default defineConfig({
       },
     }),
   ],
+  performance: {
+    chunkSplit: {
+      override: {
+        cacheGroups: {
+          vanillaCss: {
+            minSize: 0,
+            chunks: 'all',
+            test: /@vanilla-extract\/webpack-plugin/,
+            priority: 1000,
+            name: process.env.NODE_ENV === 'development' && 'vanilla-extract',
+          },
+        },
+      },
+    },
+  },
   tools: {
     rspack: {
       plugins: [new VanillaExtractPlugin()],


### PR DESCRIPTION
Add special cacheGroups to handle vanilla extract modules, so we can avoid HMR issue in Rspack

see:
https://github.com/vanilla-extract-css/vanilla-extract/issues/905
https://github.com/web-infra-dev/rsbuild/issues/6049