### PR TITLE
fix(rsbuild-rstest): include @rstest/core/globals in types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,8 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
-  }
+  },
+  "cSpell.words": [
+    "rstest"
+  ]
 }

--- a/rsbuild/react-rstest/tests/tsconfig.json
+++ b/rsbuild/react-rstest/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom", "@rstest/core/globals"]
   },
   "include": ["./"]
 }


### PR DESCRIPTION
https://rstest.rs/config/test/globals#typescript-support