### PR TITLE
ci: use pnpm exec for playwright install to match lockfile version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm --filter @rstest-example/browser-locator exec playwright install --with-deps chromium
 
       - name: Build Rspack
         run: |


### PR DESCRIPTION
## Problem

`pnpm dlx playwright install chromium` pulls the **latest** playwright CLI to download browsers. When the latest playwright version diverges from the project's locked version (`playwright@1.58.1`), the downloaded chromium revision won't match what `@rstest/browser` expects at runtime.

- `pnpm dlx` downloaded **chromium v1217** (latest playwright)
- `@rstest/browser` (via `playwright@1.58.1`) expected **chromium v1208**

This caused: https://github.com/rstackjs/rstack-examples/actions/runs/23829705206/job/69460295174

## Fix

Use `pnpm exec playwright install --with-deps chromium` so the project's own locked playwright binary downloads the matching browser revision.