### PR TITLE
fix(rspack): refine nestjs example

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2507,9 +2507,6 @@ importers:
       '@rspack/dev-server':
         specifier: 2.0.1
         version: 2.0.1(@rspack/core@2.0.2)
-      cross-env:
-        specifier: 10.1.0
-        version: 10.1.0
       webpack-node-externals:
         specifier: 3.0.0
         version: 3.0.0

--- a/rspack/nestjs/package.json
+++ b/rspack/nestjs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "cross-env BUILD=true rspack build",
+    "build": "rspack build",
     "dev": "rspack dev",
     "start": "node dist/main.js"
   },
@@ -20,7 +20,6 @@
     "@rspack/cli": "2.0.2",
     "@rspack/core": "2.0.2",
     "@rspack/dev-server": "2.0.1",
-    "cross-env": "10.1.0",
     "webpack-node-externals": "3.0.0"
   }
 }

--- a/rspack/nestjs/rspack.config.mjs
+++ b/rspack/nestjs/rspack.config.mjs
@@ -62,7 +62,7 @@ export default defineConfig({
   },
   externalsType: 'commonjs',
   plugins: [
-    !process.env.BUILD &&
+    process.env.NODE_ENV !== 'production' &&
       new RunScriptWebpackPlugin({
         name: 'main.js',
         autoRestart: false,

--- a/rspack/nestjs/rspack.config.mjs
+++ b/rspack/nestjs/rspack.config.mjs
@@ -4,13 +4,14 @@ import { rspack } from '@rspack/core';
 import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
 import nodeExternals from 'webpack-node-externals';
 
-const isProduction = process.env.BUILD === 'true';
-
 export default defineConfig({
   context: import.meta.dirname,
   target: 'node',
   entry: {
-    main: isProduction ? './src/main.ts' : ['@rspack/core/hot/poll?100', './src/main.ts'],
+    main:
+      process.env.BUILD === 'true'
+        ? './src/main.ts'
+        : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },
   output: {
     clean: true,

--- a/rspack/nestjs/rspack.config.mjs
+++ b/rspack/nestjs/rspack.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
   target: 'node',
   entry: {
     main:
-      process.env.BUILD === 'true'
+      process.env.NODE_ENV === 'production'
         ? './src/main.ts'
         : ['@rspack/core/hot/poll?100', './src/main.ts'],
   },


### PR DESCRIPTION
## Summary

- Inline the NestJS example production build check directly in the Rspack entry configuration.
- Remove the separate `isProduction` helper constant while preserving the same dev and build behavior.

## Validation

- `pnpm --filter @rspack-example/nestjs build`
