### PR TITLE
chore(deps): add missing package to the tanstack rsc example

### DIFF
--- a/rsbuild/tanstack-start-rsc/package.json
+++ b/rsbuild/tanstack-start-rsc/package.json
@@ -14,6 +14,7 @@
     "dexie": "^4.0.10",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-server-dom-rspack": "^0.0.2",
     "srvx": "^0.11.16",
     "tailwindcss": "^4.3.0",
     "zod": "^4.4.3",


### PR DESCRIPTION
Not sure if that's valid, but while trying out this example, this missing package was failing the build