### PR TITLE
fix(rstest): use sync mock factory in mocking example

### DIFF
--- a/rstest/mocking/tests/dynamic-mock.test.ts
+++ b/rstest/mocking/tests/dynamic-mock.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, rs, rstest } from '@rstest/core';
+import { formatDate as actualFormatDate } from '../src/utils' with { rstest: 'importActual' };
 
 describe('rs.doMock() - Dynamic Module Mocking', () => {
   /**
@@ -87,15 +88,10 @@ describe('rs.importActual() - Import Original Module', () => {
    */
 
   it('should import actual module inside mock', async () => {
-    rs.doMock('../src/utils', async () => {
-      const actual = await rs.importActual<typeof import('../src/utils')>('../src/utils');
-
-      return {
-        ...actual,
-        // Override only specific functions
-        generateId: () => 'overridden-id',
-      };
-    });
+    rs.doMock('../src/utils', () => ({
+      formatDate: actualFormatDate,
+      generateId: () => 'overridden-id',
+    }));
 
     const utils = await import('../src/utils');
 


### PR DESCRIPTION
## Why

The `rstest/mocking` example fails on rstest 0.9.x ([eco-ci run](https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/28028067725/job/82960957722)):

```
Error: [Rstest] An async mock factory is not supported. Use a sync factory;
to keep part of the original module, import it with `with { rstest: 'importActual' }` and spread it in.
```

The rstest-side change (rejecting async mock factories) is intentional, so the example needs updating.

## What

In `tests/dynamic-mock.test.ts`, the `should import actual module inside mock` case used an async factory with `await rs.importActual(...)`. Switched it to the supported pattern: load the original module via the `with { rstest: 'importActual' }` import attribute and use a synchronous factory.

## Verify

`pnpm test` in `rstest/mocking` — all 60 tests pass.