### PR TITLE
chore: update the Rslib React Compiler example to use SWC

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@swc/plugin-emotion':
         specifier: ^14.12.0
         version: 14.12.0
@@ -112,16 +112,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.0
-        version: 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@rsbuild/core':
         specifier: 2.0.9
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -143,16 +143,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.0
-        version: 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@rsbuild/core':
         specifier: 2.0.9
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -177,7 +177,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -196,7 +196,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -231,7 +231,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -256,7 +256,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -284,7 +284,7 @@ importers:
         version: 1.2.1(@rsbuild/core@2.0.9)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -312,10 +312,10 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-eslint':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(eslint@9.39.4)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(eslint@9.39.4)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -355,7 +355,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.0.9)(webpack@5.102.1)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -383,7 +383,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.0.9)(webpack@5.102.1)
@@ -411,7 +411,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -466,7 +466,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -516,7 +516,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -544,7 +544,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -578,7 +578,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -615,7 +615,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rsbuild/plugin-styled-components':
         specifier: ^1.6.2
         version: 1.6.2(@rsbuild/core@2.0.9)
@@ -646,7 +646,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@swc/plugin-styled-jsx':
         specifier: ^13.12.0
         version: 13.12.0
@@ -677,7 +677,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -720,7 +720,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.11)(@tanstack/router-core@1.171.9)(csstype@3.2.3)(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.19
-        version: 1.168.19(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
+        version: 1.168.19(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/router-plugin':
         specifier: ^1.168.14
         version: 1.168.14(@rsbuild/core@2.0.11)(@tanstack/react-router@1.170.11)(vite@8.0.16)(webpack@5.102.1)
@@ -742,7 +742,7 @@ importers:
         version: 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.0.11)(webpack@5.102.1)
@@ -772,7 +772,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.11)(@tanstack/router-core@1.171.9)(csstype@3.2.3)(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.19
-        version: 1.168.19(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
+        version: 1.168.19(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
       dexie:
         specifier: ^4.0.10
         version: 4.4.3
@@ -784,7 +784,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       react-server-dom-rspack:
         specifier: ^0.0.2
-        version: 0.0.2(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7)
+        version: 0.0.2(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7)
       srvx:
         specifier: ^0.11.16
         version: 0.11.16
@@ -803,7 +803,7 @@ importers:
         version: 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
         version: 2.0.1(@rsbuild/core@2.0.11)(webpack@5.102.1)
@@ -895,7 +895,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -920,7 +920,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -936,7 +936,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -958,7 +958,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -980,10 +980,10 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-eslint':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(eslint@9.39.4)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(eslint@9.39.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.60.0
         version: 8.60.0(@typescript-eslint/parser@8.60.0)(eslint@9.39.4)(typescript@5.9.3)
@@ -1014,10 +1014,10 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(webpack@5.102.1)
+        version: 1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(webpack@5.102.1)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)
       '@vant/auto-import-resolver':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1051,10 +1051,10 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.12
-        version: 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(webpack@5.102.1)
+        version: 1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(webpack@5.102.1)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -1088,7 +1088,7 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.12
-        version: 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.5)(webpack@5.102.1)
+        version: 1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rspack/cli':
         specifier: 2.0.5
         version: 2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3)
@@ -1131,19 +1131,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
       '@rspress/core':
         specifier: ^2.0.13
-        version: 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)
+        version: 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.1.2)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)
       '@rspress/plugin-api-docgen':
         specifier: ^2.0.13
         version: 2.0.13(@rspress/core@2.0.13)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)
       '@rspress/plugin-preview':
         specifier: ^2.0.13
-        version: 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@rspress/core@2.0.13)(core-js@3.49.0)(react-dom@19.2.6)(react@19.2.6)
+        version: 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.1.2)(@rspress/core@2.0.13)(core-js@3.49.0)(react-dom@19.2.6)(react@19.2.6)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1170,13 +1170,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@rsbuild/core':
         specifier: ~2.0.9
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -1191,16 +1191,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.0
-        version: 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/storybook-addon':
         specifier: ^6.0.12
-        version: 6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)
+        version: 6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
@@ -1218,13 +1218,13 @@ importers:
         version: 19.2.6(react@19.2.6)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+        version: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.11)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.1.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1)
+        version: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1)
 
   rslib/module-federation/mf-remote:
     dependencies:
@@ -1237,13 +1237,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@rsbuild/core':
         specifier: ~2.0.9
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -1288,7 +1288,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-preact':
         specifier: ^1.7.3
-        version: 1.7.3(@rsbuild/core@2.0.11)(preact@10.29.2)
+        version: 1.7.3(@rsbuild/core@2.1.1)(preact@10.29.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1307,7 +1307,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1327,21 +1327,15 @@ importers:
         specifier: '>=19.0.0'
         version: 19.2.5(react@19.2.6)
     devDependencies:
-      '@rsbuild/plugin-babel':
-        specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.0.11)
       '@rsbuild/plugin-react':
-        specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        specifier: ^2.1.0
+        version: 2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
-        specifier: ^0.22.0
-        version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
+        specifier: ^0.23.1
+        version: 0.23.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
-      babel-plugin-react-compiler:
-        specifier: ^1.0.0
-        version: 1.0.0
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -1357,7 +1351,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1379,10 +1373,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(webpack@5.102.1)
+        version: 1.6.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(webpack@5.102.1)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1404,7 +1398,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1441,10 +1435,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.11)
+        version: 1.5.3(@rsbuild/core@2.1.1)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1465,7 +1459,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1489,13 +1483,13 @@ importers:
         version: 19.2.6(react@19.2.6)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+        version: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       storybook-addon-rslib:
         specifier: ^3.3.4
         version: 3.3.4(@rsbuild/core@2.0.9)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1)
+        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1508,7 +1502,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1536,7 +1530,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1557,10 +1551,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: ^1.2.1
-        version: 1.2.1(@rsbuild/core@2.0.11)
+        version: 1.2.1(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.1
-        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.0.11)(solid-js@1.9.13)
+        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.1.1)(solid-js@1.9.13)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1578,7 +1572,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-svelte':
         specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.29.7)(@rsbuild/core@2.0.11)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
+        version: 1.1.2(@babel/core@7.29.7)(@rsbuild/core@2.1.1)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1605,10 +1599,10 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.0.11)
+        version: 1.5.3(@rsbuild/core@2.1.1)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1626,7 +1620,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1644,7 +1638,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1683,7 +1677,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.9
-        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)
+        version: 1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1698,13 +1692,13 @@ importers:
         version: 10.4.1(storybook@10.4.1)(vue@3.5.35)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
         version: 3.3.4(@rsbuild/core@2.0.9)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1)
+        version: 3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3960,7 +3954,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
         version: 0.10.3(@rsbuild/core@2.0.9)(@rstest/core@0.10.3)
@@ -3999,7 +3993,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
         version: 0.10.3(@rsbuild/core@2.0.9)(@rstest/core@0.10.3)
@@ -4141,7 +4135,7 @@ importers:
         version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)
+        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -4238,7 +4232,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.5)
+        version: 2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.0.5)
       '@rspack/cli':
         specifier: 2.0.5
         version: 2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3)
@@ -5271,17 +5265,26 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -6603,6 +6606,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nestjs/common@11.1.9':
     resolution: {integrity: sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==}
     peerDependencies:
@@ -7540,6 +7549,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.1.1':
+    resolution: {integrity: sha512-s6Cc+pHCJK9RP6Yk4LwsQWHxxxasrk5kmo9nkZK7j1iObp4w2PLivsUdP6HtkeoXuxcnK3QKH8/r49plNBjaQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.1.2':
     resolution: {integrity: sha512-qIZzosQlkj7VyFz8mmz1vAKDFlk79xrIvCRYzROqNwQHDXep+gd91nCnUPJdRPHrktzN8Yqa190CPTii3rON6w==}
     peerDependencies:
@@ -7602,6 +7621,14 @@ packages:
     resolution: {integrity: sha512-n5m3VxEm6m3Dv1VkI0WnxsildySJ6M+QjGIzkZDy5UebRCIJ1Q/hlQVyhofBL6C+AcsF9fGjlHQkeiteXJSr3Q==}
     peerDependencies:
       '@rsbuild/core': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
+  '@rsbuild/plugin-react@2.1.0':
+    resolution: {integrity: sha512-RQTIAWB/CwPjoWt9iAl+8HixeQVgZ7kEIBrWPCixfITyHdiD84h0YpUTpEUuz6kGHw1KXT9mHZ3Rwy6WG7aRDA==}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -7717,6 +7744,19 @@ packages:
       typescript:
         optional: true
 
+  '@rslib/core@0.23.1':
+    resolution: {integrity: sha512-kATUdbAwWL12Zrvuiv4M9JmwxG0pvH7zAJeQpPwMgGbs6uWPG4jA89DQEDyoBFmM/p4flBXN40x+42hbN+Bhbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      typescript: ^5 || ^6 || ^7.0.1-0
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+
   '@rslint/core@0.5.3':
     resolution: {integrity: sha512-7s7Yb9L0mwI2sl06G5HTI7ENd1iJiGYFVWbHjeJbXa7bLM5rPwkgWsYMRZo4kYQIYqpqD4Oqraor+zawEcunkw==}
     hasBin: true
@@ -7771,6 +7811,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.1.2':
+    resolution: {integrity: sha512-IYcxareUOYJZz+uNMSIwn+iDRiVyjZNOjoxO/zL4OFaPK8Ncrw0ka/9DqL9Gd7OpnAXN1zK3uS8yD0O1yIYI3Q==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.6.7':
     resolution: {integrity: sha512-DpQRxxTXkMMNPmBXeJBaAB8HmWKxH2IfvHv7vU+kBhJ3xdPtXU4/xBv1W3biluoNRG11gc1WLIgjzeGgaLCxmw==}
     cpu: [x64]
@@ -7783,6 +7828,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.0.6':
     resolution: {integrity: sha512-/mMo2IpI02aOKMlHbVbZue3TJxFqHGX+ibVTdEO+6bzRSuHs7+R9KM5U3XH2YxcWJy5Sid1X1T1pJAjsXcE3rA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.1.2':
+    resolution: {integrity: sha512-aoifkILvx/XEHyvg8yW57xu95nx7f9f/3ah1+RguHSNKcJMcoCep9VX1Ct1N0ftqg8MC0JUObc7xWL5W14hmjA==}
     cpu: [x64]
     os: [darwin]
 
@@ -7800,6 +7850,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.0.6':
     resolution: {integrity: sha512-H6ACzeM1KBxYDEF8YAim3501Jb1aCsSG79Gjm1M4pwJ5OJPK2ydiJEa438ugXmh0962eKYMHI2yZY0sQq8txaw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.2':
+    resolution: {integrity: sha512-My4m40tyJSgiCEf3bB2KIEX710q3nZg99LIjy+8Zxgi3oZTkg1bFmFRusFU5U4eN5408zfSqDDGvjDE3Yv7o4w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -7822,6 +7878,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.1.2':
+    resolution: {integrity: sha512-yt+GGWUH7WPE8K97cRc8OpZhH7Pbj1vU+lkvKbDtF/rR8X9a/bJsA/nBqyUV2oBKOVbrp5I8rFZlnDskMqgvKw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.2':
+    resolution: {integrity: sha512-uys8Jyw8Z3ralvICbN/L/nZfy5qELIwpOY72rhIqhoDYwFcL4fmMaY7WsvUcJOjCB2rqOcWPaWKuF2oPvo9iDQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.2':
+    resolution: {integrity: sha512-JYNVQwqCaRGQWvjHQYzZkIzQiwllMaJwh4Rdu3ww6W2OJcJUqT08sL1pkOtU0iCxT4VUYiRRcp93VGTGpHr8fg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@1.6.7':
     resolution: {integrity: sha512-iMrE0Q4IuYpkE0MjpaOVaUDYbQFiCRI9D3EPoXzlXJj4kJSdNheODpHTBVRlWt8Xp7UAoWuIFXCvKFKcSMm3aQ==}
     cpu: [x64]
@@ -7836,6 +7910,12 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.0.6':
     resolution: {integrity: sha512-rerCAz022zf0ewxI+7n3SrqLEaxCL+MXRxKjK5FLUGFa8UkIrivq+VUP/1OB6JLh2Bucebc7Y9WoWHvtk22mLA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.2':
+    resolution: {integrity: sha512-KDoPy0Msf/JLhxgPPrJQzZeB4Qpqd32em8AP5lSW2s6jR5I35dHgAe9xc2A++EQtnSrU4GTn6DBvFC7q84SihQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -7858,6 +7938,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.1.2':
+    resolution: {integrity: sha512-66hWmIGvn4zCKAYXJE9Bp5SNSLYnLFq2Ke/efE+ZtWy43Dd5vk9AAOmThVGBwdwmIxmGtHGCp+cAuS4G0wu0TA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@1.6.7':
     resolution: {integrity: sha512-yx88EFdE9RP3hh7VhjjW6uc6wGU0KcpOcZp8T8E/a+X8L98fX0aVrtM1IDbndhmdluIMqGbfJNap2+QqOCY9Mw==}
     cpu: [wasm32]
@@ -7868,6 +7954,10 @@ packages:
 
   '@rspack/binding-wasm32-wasi@2.0.6':
     resolution: {integrity: sha512-0aWiF+qmdb0csp1x+MaR2o1pscoquLaEbLTVdKjmoTRs6sguMemtB1ObnVTahAUL73P66WePuNpFAJ81zNdqzQ==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.1.2':
+    resolution: {integrity: sha512-EB4SqH8DW/E/OmqssNQvnIVGQiVUyYNlA/pcc6Ia4MlTNwu6eNDppcNLrToH+kSZpL4CpHSFfSM3eIsSuar2Rw==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.6.7':
@@ -7882,6 +7972,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.0.6':
     resolution: {integrity: sha512-BX638A1MXsjc2E3tUskVh3X/WBIHjLKK+lo395v7MmEL9u2BA6l3F6RyW+YaJOt5aEOOv83iA7iCZsviVZ49Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.2':
+    resolution: {integrity: sha512-T6Fs/g32MRja/UpCq4AdyPRj8tA0cOkcEa4PrAcn/ztUgK8b/qMVxj5mhMI+n7k+kHZQnpeB1Q4HqdSJi6OocA==}
     cpu: [arm64]
     os: [win32]
 
@@ -7900,6 +7995,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.1.2':
+    resolution: {integrity: sha512-OtxkFVz14mVL4QK8QriSELn9B6PaYGHw1jGJwVDEzpu2ZxSHCTQPz9dVE1ekYtREEqZUkRU7Fp7VfhJSmjTt2Q==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.6.7':
     resolution: {integrity: sha512-8xlbuJQtYktlBjZupOHlO8FeZqSIhsV3ih7xBSiOYar6LI6uQzA7XiO3I5kaPSDirBMMMKv1Z4rKCxWx10a3TQ==}
     cpu: [x64]
@@ -7915,6 +8015,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.1.2':
+    resolution: {integrity: sha512-Am+nx9fLF3nzgD/K05Bs1Bb+WO8SFLWAYRbXkymaL1r+RQxjRj7jd5ap2PhGOCcfaNA4yVWkAFvmFP92eRu7bQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.6.7':
     resolution: {integrity: sha512-7ICabuBN3gHc6PPN52+m1kruz3ogiJjg1C0gSWdLRk18m/4jlcM2aAy6wfXjgODJdB0Yh2ro/lIpBbj+AYWUGA==}
 
@@ -7923,6 +8028,9 @@ packages:
 
   '@rspack/binding@2.0.6':
     resolution: {integrity: sha512-z5EO9mPlmYNpHAlRGub0Chr6D+Klgy+tX36n7tCm7VRGRlwTmTU9wSENrYbHcCpFbegtrE0s30rDeTBeOu+JiQ==}
+
+  '@rspack/binding@2.1.2':
+    resolution: {integrity: sha512-/mFcRSUW7Pl19KeaBIujJvZYNJQu0wD5D3aa5h+Qcph26v7nmLYlX7eajIHGi8tt2qTZX1lXifw2KLIXKwYaRQ==}
 
   '@rspack/cli@2.0.5':
     resolution: {integrity: sha512-AAyuY/8sfegb0IcsFEhn5gLOTxy1uDmwjP49RY81PENz2pCk/7NU0zDdt0ke5wmpOH5s6IxS+Kw4aWdvl8FGpQ==}
@@ -7957,6 +8065,18 @@ packages:
 
   '@rspack/core@2.0.6':
     resolution: {integrity: sha512-ronRqH1T2dYdMFVOQbGvDNxYaLugQK8qhNYYtS2DbOvPKQYvdIYWDenL9k/WV+hLoknnPWMn2ME2cKJcK3Po+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.1.2':
+    resolution: {integrity: sha512-crpNQKhHfnzrIl4Sa4fjH30Ho5aAPgyqpmJZ41SkUFOzyKHdZKYfE5LF3CMh7MiFQFPPxiiKf5BcpxmtZZx4MQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8012,6 +8132,15 @@ packages:
     resolution: {integrity: sha512-rYmxHJeDhN9/neZJgEjSFqG20A2Mu1mKv8+15kgwyuIDFSd3cgP3OVxwXLz5UmZSmWAfSzayDmmU1tBT0j1Nxw==}
     peerDependencies:
       '@rspack/core': ^2.0.0-0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  '@rspack/plugin-react-refresh@2.0.2':
+    resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       '@rspack/core':
@@ -9060,6 +9189,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -14334,6 +14466,22 @@ packages:
       typescript:
         optional: true
 
+  rsbuild-plugin-dts@0.23.1:
+    resolution: {integrity: sha512-RB3gbeT5dsmh1Q3uukKHSviYs7ul0PHtLa8WfkJSRu44E+VpRlYalAX1W7lqPt0dnKE+JhpCX7wuf98o1RJYjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@typescript/native-preview': ^7.0.0-0
+      typescript: ^5 || ^6 || ^7.0.1-0
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+
   rsbuild-plugin-html-minifier-terser@1.1.3:
     resolution: {integrity: sha512-Ru+OdDRxFBQIFtHU/jISO60WORECsEG00s7QmvvlbOxxJt6tx9R2sNmRAp/C7JmSeJXGUhl7M+bi0BJpu8gQ4A==}
     peerDependencies:
@@ -18300,6 +18448,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -18311,12 +18465,22 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -19297,7 +19461,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
@@ -19306,7 +19470,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -19323,7 +19487,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
@@ -19332,7 +19496,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -19390,9 +19554,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.0.6)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
+  '@module-federation/node@2.7.43(@rspack/core@2.1.2)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -19407,9 +19571,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.0.6)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
+  '@module-federation/node@2.7.43(@rspack/core@2.1.2)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -19424,26 +19588,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
-      '@module-federation/node': 2.7.43(@rspack/core@2.0.6)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
-      '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-    optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - node-fetch
-      - typescript
-      - utf-8-validate
-      - vue-tsc
-      - webpack
-
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
-    dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
-      '@module-federation/node': 2.7.43(@rspack/core@2.0.6)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/node': 2.7.43(@rspack/core@2.1.2)(typescript@5.9.3)(vue-tsc@3.3.3)(webpack@5.102.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
@@ -19456,7 +19604,23 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)':
+    dependencies:
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/node': 2.7.43(@rspack/core@2.1.2)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - node-fetch
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - webpack
+
+  '@module-federation/rspack@2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
@@ -19465,7 +19629,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 5.9.3
       vue-tsc: 3.3.3(typescript@5.9.3)
@@ -19474,7 +19638,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
+  '@module-federation/rspack@2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
@@ -19483,7 +19647,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.3(typescript@6.0.3)
@@ -19536,13 +19700,13 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)':
+  '@module-federation/storybook-addon@6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.0.6)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.2)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.3)(webpack@5.102.1)
     optionalDependencies:
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       webpack: 5.102.1(lightningcss@1.32.0)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -19585,11 +19749,25 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)':
@@ -19868,9 +20046,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -20255,6 +20433,15 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.11)':
     dependencies:
       '@babel/core': 7.29.7
@@ -20294,6 +20481,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.1.1)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@types/babel__core': 7.20.5
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.9)':
     dependencies:
       acorn: 8.16.0
@@ -20304,35 +20504,35 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
-  '@rsbuild/plugin-eslint@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(eslint@9.39.4)':
+  '@rsbuild/plugin-eslint@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(eslint@9.39.4)':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
-      eslint-rspack-plugin: 5.0.0(@rspack/core@2.0.6)(eslint@9.39.4)
+      eslint-rspack-plugin: 5.0.0(@rspack/core@2.1.2)(eslint@9.39.4)
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.3(@rspack/core@2.0.6)(less@4.6.4)(webpack@5.102.1)
+      less-loader: 12.3.3(@rspack/core@2.1.2)(less@4.6.4)(webpack@5.102.1)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.3(@rspack/core@2.0.6)(less@4.6.4)(webpack@5.102.1)
+      less-loader: 12.3.3(@rspack/core@2.1.2)(less@4.6.4)(webpack@5.102.1)
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
@@ -20346,17 +20546,6 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-preact@1.7.3(@rsbuild/core@2.0.11)(preact@10.29.2)':
-    dependencies:
-      '@prefresh/core': 1.5.10(preact@10.29.2)
-      '@prefresh/utils': 1.2.1
-      '@rspack/plugin-preact-refresh': 1.1.6(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)
-      '@swc/plugin-prefresh': 12.12.0
-    optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-    transitivePeerDependencies:
-      - preact
-
   '@rsbuild/plugin-preact@1.7.3(@rsbuild/core@2.0.9)(preact@10.29.2)':
     dependencies:
       '@prefresh/core': 1.5.10(preact@10.29.2)
@@ -20368,7 +20557,18 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.5)':
+  '@rsbuild/plugin-preact@1.7.3(@rsbuild/core@2.1.1)(preact@10.29.2)':
+    dependencies:
+      '@prefresh/core': 1.5.10(preact@10.29.2)
+      '@prefresh/utils': 1.2.1
+      '@rspack/plugin-preact-refresh': 1.1.6(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)
+      '@swc/plugin-prefresh': 12.12.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - preact
+
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.11)':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
       react-refresh: 0.18.0
@@ -20377,25 +20577,52 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.2)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.2)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.11)':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.0.5)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.2)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.2)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.1)':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -20403,7 +20630,7 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
   '@rsbuild/plugin-solid@1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.0.11)(solid-js@1.9.13)':
     dependencies:
@@ -20429,6 +20656,18 @@ snapshots:
       - solid-js
       - supports-color
 
+  '@rsbuild/plugin-solid@1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.1.1)(solid-js@1.9.13)':
+    dependencies:
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.1.1)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
+      solid-refresh: 0.7.8(solid-js@1.9.13)
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - solid-js
+      - supports-color
+
   '@rsbuild/plugin-styled-components@1.6.2(@rsbuild/core@2.0.9)':
     dependencies:
       '@swc/plugin-styled-components': 12.12.1
@@ -20436,12 +20675,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
-  '@rsbuild/plugin-svelte@1.1.2(@babel/core@7.29.7)(@rsbuild/core@2.0.11)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)':
+  '@rsbuild/plugin-svelte@1.1.2(@babel/core@7.29.7)(@rsbuild/core@2.0.9)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)':
     dependencies:
       svelte-loader: 3.2.4(svelte@5.56.0)
       svelte-preprocess: 6.0.3(@babel/core@7.29.7)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -20455,12 +20694,12 @@ snapshots:
       - svelte
       - typescript
 
-  '@rsbuild/plugin-svelte@1.1.2(@babel/core@7.29.7)(@rsbuild/core@2.0.9)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)':
+  '@rsbuild/plugin-svelte@1.1.2(@babel/core@7.29.7)(@rsbuild/core@2.1.1)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)':
     dependencies:
       svelte-loader: 3.2.4(svelte@5.56.0)
       svelte-preprocess: 6.0.3(@babel/core@7.29.7)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -20490,27 +20729,27 @@ snapshots:
     transitivePeerDependencies:
       - webpack
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.0.6)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.1.2)(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.0.6)(typescript@5.9.3)
+      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.1.2)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
@@ -20520,19 +20759,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
-  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)':
+  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(vue@3.5.35)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.0.6)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
-    optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@vue/compiler-sfc'
-      - vue
-
-  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(vue@3.5.35)':
-    dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.0.6)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.2)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
@@ -20540,16 +20769,26 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
+  '@rsbuild/plugin-vue@1.2.9(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)':
+    dependencies:
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.2)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@vue/compiler-sfc'
+      - vue
+
   '@rsdoctor/client@1.5.12': {}
 
-  '@rsdoctor/core@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsdoctor/core@1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.9)
-      '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/sdk': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/types': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/utils': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rsdoctor/graph': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/sdk': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       browserslist-load-config: 1.0.1
       es-toolkit: 1.45.1
       filesize: 11.0.17
@@ -20566,14 +20805,14 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/core@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.5)(webpack@5.102.1)':
+  '@rsdoctor/core@1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rspack/core@2.0.5)(webpack@5.102.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.9)
       '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rsdoctor/sdk': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rsdoctor/types': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rsdoctor/utils': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
-      '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       browserslist-load-config: 1.0.1
       es-toolkit: 1.45.1
       filesize: 11.0.17
@@ -20601,10 +20840,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/graph@1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsdoctor/graph@1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
-      '@rsdoctor/types': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/utils': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
       es-toolkit: 1.45.1
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -20612,15 +20851,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/sdk': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/types': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/utils': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
+      '@rsdoctor/core': 1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/graph': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/sdk': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -20630,9 +20869,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.5)(webpack@5.102.1)':
+  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rspack/core@2.0.5)(webpack@5.102.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.5)(webpack@5.102.1)
+      '@rsdoctor/core': 1.5.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rsdoctor/sdk': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
       '@rsdoctor/types': 1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)
@@ -20665,12 +20904,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsdoctor/sdk@1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
       '@rsdoctor/client': 1.5.12
-      '@rsdoctor/graph': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/types': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
-      '@rsdoctor/utils': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
+      '@rsdoctor/graph': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -20692,14 +20931,14 @@ snapshots:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1
 
-  '@rsdoctor/types@1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsdoctor/types@1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1
 
   '@rsdoctor/utils@1.5.12(@rspack/core@2.0.5)(webpack@5.102.1)':
@@ -20723,10 +20962,10 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/utils@1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)':
+  '@rsdoctor/utils@1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.12(@rspack/core@2.0.6)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.1.2)(webpack@5.102.1)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -20761,6 +21000,17 @@ snapshots:
       rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.11)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@typescript/native-preview'
+      - core-js
+
+  '@rslib/core@0.23.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)':
+    dependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.23.1(@rsbuild/core@2.1.1)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
@@ -20806,6 +21056,9 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.6':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.1.2':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.6.7':
     optional: true
 
@@ -20813,6 +21066,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.6':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.2':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.6.7':
@@ -20824,6 +21080,9 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.0.6':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.1.2':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.6.7':
     optional: true
 
@@ -20831,6 +21090,15 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.6':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.2':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.2':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.2':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.6.7':
@@ -20842,6 +21110,9 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.0.6':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.1.2':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.6.7':
     optional: true
 
@@ -20849,6 +21120,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.6':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.2':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.6.7':
@@ -20870,6 +21144,13 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.1.2':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.6.7':
     optional: true
 
@@ -20877,6 +21158,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.6':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.6.7':
@@ -20888,6 +21172,9 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.0.6':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.1.2':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.6.7':
     optional: true
 
@@ -20895,6 +21182,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.6':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.2':
     optional: true
 
   '@rspack/binding@1.6.7':
@@ -20936,6 +21226,21 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.6
       '@rspack/binding-win32-x64-msvc': 2.0.6
 
+  '@rspack/binding@2.1.2':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.2
+      '@rspack/binding-darwin-x64': 2.1.2
+      '@rspack/binding-linux-arm64-gnu': 2.1.2
+      '@rspack/binding-linux-arm64-musl': 2.1.2
+      '@rspack/binding-linux-riscv64-gnu': 2.1.2
+      '@rspack/binding-linux-riscv64-musl': 2.1.2
+      '@rspack/binding-linux-x64-gnu': 2.1.2
+      '@rspack/binding-linux-x64-musl': 2.1.2
+      '@rspack/binding-wasm32-wasi': 2.1.2
+      '@rspack/binding-win32-arm64-msvc': 2.1.2
+      '@rspack/binding-win32-ia32-msvc': 2.1.2
+      '@rspack/binding-win32-x64-msvc': 2.1.2
+
   '@rspack/cli@2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3)':
     dependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
@@ -20964,6 +21269,13 @@ snapshots:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
 
+  '@rspack/core@2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.1.2
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
+
   '@rspack/dev-middleware@2.0.1(@rspack/core@2.0.5)':
     optionalDependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
@@ -20988,17 +21300,23 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.6)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.2)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   '@rspack/plugin-react-refresh@2.0.1(@rspack/core@2.0.5)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.2)(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -21018,9 +21336,9 @@ snapshots:
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     optional: true
 
-  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -21035,7 +21353,7 @@ snapshots:
   '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
     optional: true
 
-  '@rspack/resolver@0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rspack/resolver@0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
       '@rspack/resolver-binding-darwin-arm64': 0.2.8
       '@rspack/resolver-binding-darwin-x64': 0.2.8
@@ -21043,7 +21361,7 @@ snapshots:
       '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
       '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
       '@rspack/resolver-binding-linux-x64-musl': 0.2.8
-      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
       '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
       '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
@@ -21051,12 +21369,12 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)':
+  '@rspress/core@2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.1.2)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.7)
       '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)
       '@rspress/shared': 2.0.13(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -21106,7 +21424,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.7)
       '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.5)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)
       '@rspress/shared': 2.0.13(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -21153,7 +21471,7 @@ snapshots:
 
   '@rspress/plugin-api-docgen@2.0.13(@rspress/core@2.0.13)(@types/react@19.2.15)(react@19.2.6)(typescript@5.9.3)':
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.1.2)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)
       documentation: 14.0.3
       github-slugger: 2.0.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
@@ -21168,12 +21486,12 @@ snapshots:
       - react
       - supports-color
 
-  '@rspress/plugin-preview@2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@rspress/core@2.0.13)(core-js@3.49.0)(react-dom@19.2.6)(react@19.2.6)':
+  '@rspress/plugin-preview@2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.1.2)(@rspress/core@2.0.13)(core-js@3.49.0)(react-dom@19.2.6)(react@19.2.6)':
     dependencies:
       '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.11)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.0.6)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.5.0)(@rspack/core@2.1.2)(@types/mdast@4.0.3)(@types/react@19.2.15)(core-js@3.49.0)(micromark-util-types@2.0.0)(micromark@4.0.0)
       picocolors: 1.1.1
       qrcode.react: 4.2.0(react@19.2.6)
       react: 19.2.6
@@ -21489,7 +21807,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.15
@@ -21502,11 +21820,11 @@ snapshots:
 
   '@storybook/addon-onboarding@10.4.1(storybook@10.4.1)':
     dependencies:
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
 
   '@storybook/csf-plugin@10.4.1(esbuild@0.28.0)(rollup@4.60.3)(storybook@10.4.1)(vite@7.1.1)(webpack@5.102.1)':
     dependencies:
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
@@ -21558,7 +21876,7 @@ snapshots:
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -21567,7 +21885,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -21580,7 +21898,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -21596,7 +21914,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.6(react@19.2.6)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -21607,7 +21925,7 @@ snapshots:
   '@storybook/vue3@10.4.1(storybook@10.4.1)(vue@3.5.35)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       type-fest: 2.19.0
       vue: 3.5.35(typescript@5.9.3)
       vue-component-type-helpers: 3.3.2
@@ -21996,7 +22314,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.18(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/react-start-rsc@0.1.18(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@tanstack/react-router': 1.170.11(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start-server': 1.167.14(crossws@0.4.5)(react-dom@19.2.7)(react@19.2.7)
@@ -22011,9 +22329,9 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@vitejs/plugin-rsc': 0.5.27(react-dom@19.2.7)(react@19.2.7)(vite@8.0.16)
-      react-server-dom-rspack: 0.0.2(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7)
+      react-server-dom-rspack: 0.0.2(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - crossws
@@ -22034,11 +22352,11 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.19(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/react-start@1.168.19(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@tanstack/react-router': 1.170.11(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start-client': 1.168.8(react-dom@19.2.7)(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.18(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
+      '@tanstack/react-start-rsc': 0.1.18(@rsbuild/core@2.0.11)(@rspack/core@2.1.2)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/react-start-server': 1.167.14(crossws@0.4.5)(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/router-utils': 1.162.1
       '@tanstack/start-client-core': 1.170.7
@@ -22352,6 +22670,11 @@ snapshots:
   '@tsconfig/svelte@5.0.8': {}
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -24737,14 +25060,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-rspack-plugin@5.0.0(@rspack/core@2.0.6)(eslint@9.39.4):
+  eslint-rspack-plugin@5.0.0(@rspack/core@2.1.2)(eslint@9.39.4):
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
       micromatch: 4.0.8
       normalize-path: 3.0.0
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   eslint-rspack-plugin@5.0.1(@rspack/core@2.0.5)(eslint@9.39.4):
     dependencies:
@@ -26372,11 +26695,11 @@ snapshots:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1(postcss@8.5.15)
 
-  less-loader@12.3.3(@rspack/core@2.0.6)(less@4.6.4)(webpack@5.102.1):
+  less-loader@12.3.3(@rspack/core@2.1.2)(less@4.6.4)(webpack@5.102.1):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1
 
   less@4.6.4:
@@ -27907,7 +28230,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -27925,7 +28248,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -28634,9 +28957,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  react-server-dom-rspack@0.0.2(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7):
+  react-server-dom-rspack@0.0.2(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
@@ -29081,12 +29404,12 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.11):
+  rsbuild-plugin-dts@0.23.1(@rsbuild/core@2.1.1)(typescript@5.9.3):
     dependencies:
-      '@types/html-minifier-terser': 7.0.2
-      html-minifier-terser: 7.2.0
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     optionalDependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      typescript: 5.9.3
 
   rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.9):
     dependencies:
@@ -29094,6 +29417,13 @@ snapshots:
       html-minifier-terser: 7.2.0
     optionalDependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.1.1):
+    dependencies:
+      '@types/html-minifier-terser': 7.0.2
+      html-minifier-terser: 7.2.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
   rsc-html-stream@0.0.7: {}
 
@@ -29113,12 +29443,12 @@ snapshots:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       vue: 3.5.35(typescript@6.0.3)
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.0.6)(@vue/compiler-sfc@3.5.35)(vue@3.5.35):
+  rspack-vue-loader@17.5.1(@rspack/core@2.1.2)(@vue/compiler-sfc@3.5.35)(vue@3.5.35):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.35
       vue: 3.5.35(typescript@5.9.3)
 
@@ -29683,58 +30013,26 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.11)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
-    dependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
-    optionalDependencies:
-      typescript: 6.0.3
-
   storybook-addon-rslib@3.3.4(@rsbuild/core@2.0.9)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3):
     dependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(typescript@6.0.3)
-      '@vitest/mocker': 3.2.4(vite@7.1.1)
-      browser-assert: 1.2.1
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 2.2.0
-      constants-browserify: 1.0.0
-      es-module-lexer: 1.7.0
-      fs-extra: 11.3.5
-      magic-string: 0.30.21
-      path-browserify: 1.0.1
-      picocolors: 1.1.1
-      process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.11)
-      sirv: 2.0.4
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      ts-dedent: 2.2.0
-      url: 0.11.4
-      util: 0.12.5
-      util-deprecate: 1.0.2
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
     optionalDependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - msw
-      - tslib
-      - vite
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1):
     dependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(typescript@5.9.3)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(typescript@5.9.3)
       '@vitest/mocker': 3.2.4(vite@7.1.1)
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -29748,7 +30046,7 @@ snapshots:
       process: 0.11.10
       rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
       sirv: 2.0.4
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -29763,10 +30061,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1):
     dependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(typescript@5.9.3)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(typescript@5.9.3)
       '@vitest/mocker': 3.2.4(vite@7.1.1)
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -29780,7 +30078,7 @@ snapshots:
       process: 0.11.10
       rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
       sirv: 2.0.4
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -29795,36 +30093,39 @@ snapshots:
       - tslib
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@rsbuild/core': 2.0.11(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@storybook/react': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)(webpack@5.102.1)
-      find-up: 5.0.0
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(typescript@6.0.3)
+      '@vitest/mocker': 3.2.4(vite@7.1.1)
+      browser-assert: 1.2.1
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 2.2.0
+      constants-browserify: 1.0.0
+      es-module-lexer: 1.7.0
+      fs-extra: 11.3.5
       magic-string: 0.30.21
-      react: 19.2.6
-      react-docgen: 8.0.3
-      react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      react-dom: 19.2.6(react@19.2.6)
-      resolve: 1.22.12
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.11)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
-      tsconfig-paths: 4.2.0
+      path-browserify: 1.0.1
+      picocolors: 1.1.1
+      process: 0.11.10
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.1)
+      sirv: 2.0.4
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      ts-dedent: 2.2.0
+      url: 0.11.4
+      util: 0.12.5
+      util-deprecate: 1.0.2
     optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@rspack/core'
-      - '@types/react'
-      - '@types/react-dom'
       - msw
-      - rollup
-      - supports-color
       - tslib
       - vite
-      - webpack
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
@@ -29837,8 +30138,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.6(react@19.2.6)
       resolve: 1.22.12
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -29853,12 +30154,41 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      '@rsbuild/core': 2.1.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@storybook/react': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)
+      '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)(webpack@5.102.1)
+      find-up: 5.0.0
+      magic-string: 0.30.21
+      react: 19.2.6
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-dom: 19.2.6(react@19.2.6)
+      resolve: 1.22.12
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.1)(@rspack/core@2.1.2)(react-dom@19.2.6)(react@19.2.6)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
+      tsconfig-paths: 4.2.0
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@types/react'
+      - '@types/react-dom'
+      - msw
+      - rollup
+      - supports-color
+      - tslib
+      - vite
+      - webpack
+
+  storybook-vue3-rsbuild@3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1):
     dependencies:
       '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@storybook/vue3': 10.4.1(storybook@10.4.1)(vue@3.5.35)
-      storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.6)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
+      storybook: 10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.1.2)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
       vue: 3.5.35(typescript@5.9.3)
       vue-docgen-api: 4.79.2(vue@3.5.35)
       vue-docgen-loader: 2.0.1(@babel/preset-env@7.29.7)(vue-docgen-api@4.79.2)(webpack@5.102.1)
@@ -29874,7 +30204,7 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6):
+  storybook@10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6)(react@19.2.6):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.6)(react@19.2.6)
@@ -29886,7 +30216,7 @@ snapshots:
       esbuild: 0.27.0
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       recast: 0.23.11
       semver: 7.8.0
       use-sync-external-store: 1.6.0(react@19.2.6)
@@ -29903,7 +30233,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7):
+  storybook@10.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
@@ -29915,7 +30245,7 @@ snapshots:
       esbuild: 0.27.0
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       recast: 0.23.11
       semver: 7.8.0
       use-sync-external-store: 1.6.0(react@19.2.7)
@@ -30562,7 +30892,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.0.6)(typescript@5.9.3):
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.1.2)(typescript@5.9.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -30570,11 +30900,11 @@ snapshots:
       picocolors: 1.1.1
       typescript: 5.9.3
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - tslib
 
-  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.0.6)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.1.2)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -30582,7 +30912,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.6(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - tslib
 

--- a/rslib/react-compiler/package.json
+++ b/rslib/react-compiler/package.json
@@ -17,11 +17,9 @@
     "dev": "rslib -w"
   },
   "devDependencies": {
-    "@rsbuild/plugin-babel": "^1.2.1",
-    "@rsbuild/plugin-react": "^2.0.1",
-    "@rslib/core": "^0.22.0",
+    "@rsbuild/plugin-react": "^2.1.0",
+    "@rslib/core": "^0.23.1",
     "@types/react": "^19.2.15",
-    "babel-plugin-react-compiler": "^1.0.0",
     "react": "^19.2.6",
     "typescript": "^5.9.3"
   },

--- a/rslib/react-compiler/rslib.config.ts
+++ b/rslib/react-compiler/rslib.config.ts
@@ -1,4 +1,3 @@
-import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rslib/core';
 
@@ -14,12 +13,8 @@ export default defineConfig({
     target: 'web',
   },
   plugins: [
-    pluginReact(),
-    pluginBabel({
-      include: /\.(?:jsx|tsx)$/,
-      babelLoaderOptions(opts) {
-        opts.plugins?.unshift('babel-plugin-react-compiler');
-      },
+    pluginReact({
+      reactCompiler: true,
     }),
   ],
 });


### PR DESCRIPTION
## Summary

This PR updates the `rslib/react-compiler` example to use the Rust-powered React Compiler provided by `@rsbuild/plugin-react` instead of the previous Babel-based setup.

It removes `@rsbuild/plugin-babel` and `babel-plugin-react-compiler`, upgrades the example to `@rsbuild/plugin-react@^2.1.0` and `@rslib/core@^0.23.1`, and enables React Compiler through `pluginReact({ reactCompiler: true })`.

## Validation

- `pnpm --filter "@rslib-example/react-compiler" build`