### PR TITLE
chore(ci): reduce Renovate memory usage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rstackjs/renovate"],
+  "env": {
+    "PNPM_MAX_WORKERS": "1"
+  },
+  "toolSettings": {
+    "nodeMaxMemory": 1536
+  },
   "ignoreDeps": ["@nestjs/common", "@nestjs/core", "@nestjs/platform-express"]
 }


### PR DESCRIPTION
## Summary

The Renovate job was terminated by the kernel OOM killer while pnpm regenerated the shared lockfile for 178 workspace projects.

This caps Renovate's Node child-process heap at 1536 MiB and limits pnpm to one worker. The tuned reproduction completed successfully with about 0.87 GiB peak RSS, leaving more memory available for the Renovate parent process and native allocations.

## Related Links

- https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project