### PR TITLE
fix: css import in tanstack-start example

### DIFF
--- a/rsbuild/tanstack-start/src/routes/__root.tsx
+++ b/rsbuild/tanstack-start/src/routes/__root.tsx
@@ -4,7 +4,7 @@ import { TanStackDevtools } from '@tanstack/react-devtools';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 
-import appCss from '../styles.css?url';
+import '../styles.css';
 
 const THEME_INIT_SCRIPT = `(function(){try{var stored=window.localStorage.getItem('theme');var mode=(stored==='light'||stored==='dark'||stored==='auto')?stored:'auto';var prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=mode==='auto'?(prefersDark?'dark':'light'):mode;var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);if(mode==='auto'){root.removeAttribute('data-theme')}else{root.setAttribute('data-theme',mode)}root.style.colorScheme=resolved;}catch(e){}})();`;
 
@@ -20,12 +20,6 @@ export const Route = createRootRoute({
       },
       {
         title: 'TanStack Start Starter',
-      },
-    ],
-    links: [
-      {
-        rel: 'stylesheet',
-        href: appCss,
       },
     ],
   }),


### PR DESCRIPTION
in production build the start injects 2 css urls: 1 for the server build and 1 for the client one. the base urls are different, so, apparently, the server link is broken.  the same happens to every asset imported with ?url, not only css. 

there's an open [PR](https://github.com/TanStack/router/pull/7590), but it doesn't look like it's gonna be merged anytime soon.
 