### PR TITLE
chore(ci): use preinstalled Chrome for browser tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright browsers
-        run: pnpm --filter @rstest-example/browser-locator exec playwright install --with-deps chromium
+      # Browser tests launch the Chrome already available on the CI runner,
+      # so Playwright does not need to download Chromium.
 
       - name: Build
         run: node --run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      # Browser tests launch the Chrome already available on the CI runner,
-      # so Playwright does not need to download Chromium.
-
       - name: Build
         run: node --run build
 

--- a/rstest/browser-locator/rstest.config.ts
+++ b/rstest/browser-locator/rstest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
     enabled: true,
     provider: 'playwright',
     browser: 'chromium',
+    // Use the preinstalled Chrome in CI to avoid downloading Playwright's Chromium.
+    providerOptions: process.env.CI
+      ? {
+          launch: {
+            channel: 'chrome',
+          },
+        }
+      : undefined,
     port: 3013,
   },
 });

--- a/rstest/browser-locator/rstest.config.ts
+++ b/rstest/browser-locator/rstest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     provider: 'playwright',
     browser: 'chromium',
     // Use the preinstalled Chrome in CI to avoid downloading Playwright's Chromium.
-    providerOptions: process.env.CI
+    providerOptions: process.env.GITHUB_ACTIONS
       ? {
           launch: {
             channel: 'chrome',

--- a/rstest/browser-rsbuild-react/rstest.config.ts
+++ b/rstest/browser-rsbuild-react/rstest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     provider: 'playwright',
     browser: 'chromium',
     // Use the preinstalled Chrome in CI to avoid downloading Playwright's Chromium.
-    providerOptions: process.env.CI
+    providerOptions: process.env.GITHUB_ACTIONS
       ? {
           launch: {
             channel: 'chrome',

--- a/rstest/browser-rsbuild-react/rstest.config.ts
+++ b/rstest/browser-rsbuild-react/rstest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
     enabled: true,
     provider: 'playwright',
     browser: 'chromium',
+    // Use the preinstalled Chrome in CI to avoid downloading Playwright's Chromium.
+    providerOptions: process.env.CI
+      ? {
+          launch: {
+            channel: 'chrome',
+          },
+        }
+      : undefined,
     port: 3012,
   },
 });

--- a/rstest/browser-rsbuild-vanilla/rstest.config.ts
+++ b/rstest/browser-rsbuild-vanilla/rstest.config.ts
@@ -5,6 +5,14 @@ export default defineConfig({
     enabled: true,
     provider: 'playwright',
     browser: 'chromium',
+    // Use the preinstalled Chrome in CI to avoid downloading Playwright's Chromium.
+    providerOptions: process.env.CI
+      ? {
+          launch: {
+            channel: 'chrome',
+          },
+        }
+      : undefined,
     port: 3010,
   },
 });

--- a/rstest/browser-rsbuild-vanilla/rstest.config.ts
+++ b/rstest/browser-rsbuild-vanilla/rstest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     provider: 'playwright',
     browser: 'chromium',
     // Use the preinstalled Chrome in CI to avoid downloading Playwright's Chromium.
-    providerOptions: process.env.CI
+    providerOptions: process.env.GITHUB_ACTIONS
       ? {
           launch: {
             channel: 'chrome',


### PR DESCRIPTION
## Summary

CI currently downloads Playwright's Chromium even though the hosted runner already provides Chrome.

This PR configures all Rstest browser examples to launch the preinstalled Chrome when `GITHUB_ACTIONS` is set and removes the redundant Playwright browser installation step. Local development continues to use Playwright's default Chromium.